### PR TITLE
chore: adopt pin rangeStrategy + keep engines as ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "prHourlyLimit": 0,
   "dependencyDashboard": true,
   "configMigration": true,
-  "rangeStrategy": "replace",
+  "rangeStrategy": "pin",
   "postUpdateOptions": ["pnpmDedupe"],
   "lockFileMaintenance": {
     "enabled": true,
@@ -80,6 +80,11 @@
       "matchPackageNames": ["pnpm"],
       "groupName": "pnpm",
       "minimumReleaseAge": "5 days"
+    },
+    {
+      "description": "Keep engines fields as ranges, never exact pins. engines declares the supported version range; the exact selectors are packageManager + .mise.toml (still pinned by the global rangeStrategy:pin). Without this override, rangeStrategy:pin rewrites engines.pnpm/engines.node to an exact version that drifts from the actual pinned versions, breaking pnpm's lockfile update with ERR_PNPM_UNSUPPORTED_ENGINE. 'replace' (unlike 'bump') only rewrites the range when a release falls outside it: pnpm 11.x / node 24.x minor+patch updates leave the ranges unchanged, and they change only at a new major.",
+      "matchDepTypes": ["engines"],
+      "rangeStrategy": "replace"
     },
     {
       "description": "5-day minimum age for production dependencies (supply-chain protection)",


### PR DESCRIPTION
## What

Converge this repo's Renovate config onto the org-standard `rangeStrategy: "pin"`, and add a packageRule that keeps the `engines` fields as ranges.

| Setting | Before | After |
|---------|--------|-------|
| Global `rangeStrategy` | `replace` | `pin` |
| `engines` override | — | `matchDepTypes: ["engines"]` → `rangeStrategy: "replace"` |

## Why

This repo was the lone outlier — every other Otto repo already uses `pin`:

| Repo | rangeStrategy |
|------|---------------|
| Otto Capture/capture | `pin` |
| Otto Bank Rec/portal | `pin` |
| Otto Bank Rec/otto | `pin` |
| Websites/withotto.app | `pin` |
| **Websites/support.withotto.app** | `replace` → **`pin`** |

`pin` gives each update a single exact target version, so `minimumReleaseAge` (the supply-chain cooldown) has one unambiguous release date to measure against, rather than a range that can straddle several releases with different dates.

The `engines` override is the companion fix from withotto.app #66: without it, `pin` would rewrite `engines.pnpm`/`engines.node` to exact versions that drift from the real selectors (`packageManager` + `.mise.toml`), breaking the pnpm lockfile update with `ERR_PNPM_UNSUPPORTED_ENGINE`. `replace` only moves a range when a release falls outside it, so 11.x / 24.x minor+patch updates leave the ranges untouched.

## Notes

- `engines.node` (`>=24.0.0 <25.0.0`) and `engines.pnpm` (`>=11.0.0 <12.0.0`) were already bounded ranges, so `package.json` needed no change.
- Renovate-only behaviour change — no effect on local `pnpm install` / `build`.
- Expect a follow-up Renovate **"Pin dependencies"** PR converting `^` caret ranges in `package.json` to exact versions, consistent with the other repos.

## Test plan

- [x] `renovate.json` parses as valid JSON; confirmed `rangeStrategy: "pin"` and the engines override resolves to `replace`.
- [x] Structurally identical to the four sibling configs Renovate already runs.
- [ ] Official `renovate-config-validator` not run — this repo's pnpm supply-chain trust policy blocks one of Renovate's transitive deps (`@yarnpkg/libzip`); policy left intact.
